### PR TITLE
feat: allow configuring concurrency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 name: release
+
 on:
   push:
     tags:
       - "v*"
+
 permissions:
   contents: write
 

--- a/internal/cmd/repos/cmd.go
+++ b/internal/cmd/repos/cmd.go
@@ -47,9 +47,11 @@ func (c *cmd) run(ctx context.Context) error {
 		return c.getRepos(ctx, ch, pg)
 	})
 
-	g.Go(func() error {
-		return c.cloneRepos(ctx, ch, pg)
-	})
+	for i := 0; i < c.opts.Workers; i++ {
+		g.Go(func() error {
+			return c.cloneRepos(ctx, ch, pg)
+		})
+	}
 
 	if err := pg.Wait(); err != nil {
 		if errors.Is(err, progress.ErrAborted) {

--- a/internal/cmd/repos/repos.go
+++ b/internal/cmd/repos/repos.go
@@ -16,7 +16,8 @@ type Options struct {
 	GitArgs      []string
 	UpstreamName string
 
-	Owner string
+	Owner   string
+	Workers int
 }
 
 func NewCmdRepos(runF func(*Options) error) *cobra.Command {
@@ -46,6 +47,7 @@ func NewCmdRepos(runF func(*Options) error) *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.UpstreamName, "upstream-remote-name", "u", "upstream", "Upstream remote name when cloning a fork")
 	cmd.Flags().StringVarP(&opts.Owner, "owner", "o", "", "Repository owner")
+	cmd.Flags().IntVar(&opts.Workers, "workers", 10, "Number of workers to spawn for cloning")
 	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		if err == pflag.ErrHelp {
 			return err


### PR DESCRIPTION
## Description

To speed up the process of cloning/syncing the repositories, the user can specify the `--workers` parameter. By default, it will use 10 workers.
